### PR TITLE
Untested fix of mix up between hue keys and chroma values used in ler…

### DIFF
--- a/lab_colour_picker/lightness_selector.py
+++ b/lab_colour_picker/lightness_selector.py
@@ -106,10 +106,11 @@ class LightnessDisplay(SelectorSurface):
             return
         
         hue = math.atan2(lab.b, lab.a)
-        ((_, low), (_, high)) = search(self.chromas, hue)
-        delta = high - low
+        ((hue_low, chroma_low), (hue_high, chroma_high)) = search(self.chromas, hue)
+        hue_delta = hue_high - hue_low
+        chroma_delta = chroma_high - chroma_low
         half_size = self.display_size / 2
-        max_ch = lerp(low, high, (hue - low) / delta) if delta > 0 else low
+        max_ch = lerp(chroma_low, chroma_high, (hue - hue_low) / hue_delta) if hue_delta > 0 else low
         ch = math.sqrt(lab.a*lab.a + lab.b*lab.b)
         self.position = (
           int(half_size + ch * math.cos(hue) * half_size / max_ch),


### PR DESCRIPTION
…p call

Untested. Previous code seemed to mix up hue key and chroma value. With the previous code the lerp call would return (hue/(high-low))*(high-low) which would be hue but with potential massive rounding errors.

This might fix some of the strange jumping selections when switching between modes and then adjusting sliders. This changed lerp could still possibly give a max chroma that is a tiny bit too large, I think, if the max chroma curve is convex between hue_low and hue_high. But this would probably be rare since the values in the chroma tree are approximate, and so slightly below anyway.

Another thing that might become a problem is hues higher than 178/180*pi get aproximate max chroma of hue 178/180*pi. If actual max chromas were decreasing for that small slice of hues that'd be a likely place to pick a max chroma too high. Not sure how important this is. Don't understand most of what is going on.